### PR TITLE
rebase MI to 0 - 100 & fixed command line opt

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -75,8 +75,12 @@ function parseCommandLine () {
             'treat for...in statements as source of cyclomatic complexity'
         ).
         option(
-            '-c, --trycatch',
+            '-t, --trycatch',
             'treat catch clauses as source of cyclomatic complexity'
+        ).
+        option(
+            '-n, --newMI',
+            'Rebase Maintainability Index betwen 0 - 100'
         );
 
     cli.parse(process.argv);
@@ -85,8 +89,10 @@ function parseCommandLine () {
         logicalor: !cli.logicalor,
         switchcase: !cli.switchcase,
         forin: cli.forin || false,
-        trycatch: cli.trycatch || false
+        trycatch: cli.trycatch || false,
+        newMI: cli.newMI || false
     };
+
 
     if (check.isUnemptyString(cli.format) === false) {
         cli.format = 'plain';

--- a/src/complexityReport.js
+++ b/src/complexityReport.js
@@ -49,6 +49,10 @@ function run (source, options) {
 
     calculateMetrics();
 
+    if (options.newMI) {
+        report.maintainability = Math.max(0, (report.maintainability*100)/171); 
+    }
+
     return report;
 }
 


### PR DESCRIPTION
Also changed the try/catch option to '-t' as '-c' conflicted with an already-existing option above it causing hilarity to ensue

for reference:
http://blogs.msdn.com/b/codeanalysis/archive/2007/11/20/maintainability-index-range-and-meaning.aspx

LOVE the module just added '-n' to rebase MI 0-100 as outlined in the above article (all the way from 2007!)...  Also the '-c' option was used twice so I changed the later one to '-t'
