### PR TITLE
Display CLI help when no files are provided

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -21,6 +21,7 @@ state = {
 };
 
 parseCommandLine();
+expectFiles(cli.args, cli.help.bind(cli));
 readFiles(cli.args);
 
 function parseCommandLine () {
@@ -102,6 +103,12 @@ function parseCommandLine () {
         cli.format = 'plain';
     }
     formatter = require('./formats/' + cli.format);
+}
+
+function expectFiles (paths, noFilesFn) {
+    if (paths.length === 0) {
+        noFilesFn();
+    }
 }
 
 function readFiles (paths) {


### PR DESCRIPTION
Not sure how you feel about this, feel free to discard. Pretty standard behaviour for Unix commands; I expected it anyway
