### PR TITLE
Improved Windows support for `jake test`

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -7,8 +7,8 @@
     var exec = require('child_process').exec,
 
     commands = {
-        test: './node_modules/.bin/mocha --ui tdd --reporter spec --colors ./test/complexityReport.js',
-        lint: './node_modules/.bin/jshint ./src --config config/jshint.json',
+        test: 'node node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors ./test/complexityReport.js',
+        lint: 'node node_modules/jshint/bin/jshint src --config config/jshint.json',
         prepare: 'npm install'
     };
 


### PR DESCRIPTION
Windows doesn't handle dot slash notation so well, so I expanded the `./`'s in `Jakefile.js` to `node ...`
