### PR TITLE
Improved output and threshold

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -215,6 +215,7 @@ function getReport (filePath, source) {
         report = cr.run(source, options);
 
         if (state.tooComplex === false && isTooComplex(report)) {
+            console.log("Module to complex:" + filePath);
             state.tooComplex = true;
         }
 


### PR DESCRIPTION
When a threshold is breached one wants to see which file caused the problem.
Also module threshold should be inverted because higher is better.
