### PR TITLE
Added regex support for testing against directory names.   

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ automatically.
 * `-p <regex>`: Specify the files to be processed
   using a regular expression to match against file names,
   defaults to `\.js$`.
+* `-r <regex>`: Specify the directory to be traversed
+  using a regular expression to match against directory names,
+  defaults to all directories.  Usefull if you want to exclude specific
+  directories such as 'node_modules': -r '^((?!node_modules).)*$'
 * `-x <number>`: Specify the maximum number of files to open concurrently,
   defaults to `1024`.
 * `-m <maintainability>`: Specify the per-module maintainability index threshold

--- a/src/cli.js
+++ b/src/cli.js
@@ -44,6 +44,10 @@ function parseCommandLine () {
             'specify the files to process using a regular expression to match against file names'
         ).
         option(
+            '-r, --dirpattern <pattern>',
+            'specify the dir to traverse using a regular expression to match against directory names'
+        ).
+        option(
             '-x, --maxfiles <number>',
             'specify the maximum number of files to have open at any point',
             parseInt
@@ -117,6 +121,10 @@ function parseCommandLine () {
     }
     cli.filepattern = new RegExp(cli.filepattern);
 
+    if (check.isUnemptyString(cli.dirpattern)) {
+        cli.dirpattern = new RegExp(cli.dirpattern);
+    }
+
     if (check.isNumber(cli.maxfiles) === false) {
         cli.maxfiles = 1024;
     }
@@ -139,7 +147,10 @@ function readFiles (paths) {
         var stat = fs.statSync(p);
 
         if (stat.isDirectory()) {
-            readDirectory(p);
+            // if no dirpattern set OR it matches to directory name
+            if (!cli.dirpattern || cli.dirpattern.test(p)) {
+                readDirectory(p);
+            }
         } else if (cli.filepattern.test(p)) {
             conditionallyReadFile(p);
         }


### PR DESCRIPTION
This is useful when excluding certain directories such as 'node_modules' with the following pattern: 

-r '^((?!node_modules).)*$'

All tests pass
