### PR TITLE
add in support for mixed coffee-script/js projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ automatically.
 -i, --forin                           treat for...in statements as source of cyclomatic complexity
 -t, --trycatch                        treat catch clauses as source of cyclomatic complexity
 -n, --newmi                           use the Microsoft-variant maintainability index (scale of 0 to 100)
+-T, --coffeescript                    include coffee-script files
 ```
 
 ### Configuration files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "complexity-report",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Software complexity analysis for JavaScript projects",
     "homepage": "https://github.com/philbooth/complexity-report",
     "bugs": "https://github.com/philbooth/complexity-report/issues",
@@ -26,6 +26,8 @@
     ],
     "dependencies": {
         "escomplex-js": "1.1.0",
+        "escomplex-coffee": "0.2.0",
+        "escomplex": "1.1.0",
         "check-types": "2.1.x",
         "commander": "2.0.x"
     },


### PR DESCRIPTION
This PR adds in support for complexity report to look at both coffee-script and JS as well as properly merging the results together for mixed coffee and js projects.

This relies on https://github.com/philbooth/escomplex/pull/10