### PR TITLE
fix race condition with loading files and add opts for new escomplex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-    "name": "complexity-report",
-    "version": "1.3.1",
-    "description": "Software complexity analysis for JavaScript projects",
-    "homepage": "https://github.com/philbooth/complexity-report",
-    "bugs": "https://github.com/philbooth/complexity-report/issues",
-    "license": "MIT",
-    "author": "Phil Booth <pmbooth@gmail.com>",
-    "bin": {
-        "cr": "./src/index.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/philbooth/complexity-report.git"
-    },
-    "keywords": [
-        "complexity",
-        "simplicity",
-        "cyclomatic",
-        "halstead",
-        "maintainability",
-        "static",
-        "analysis",
-        "metrics",
-        "escomplex"
-    ],
-    "dependencies": {
-        "escomplex-js": "1.1.0",
-        "escomplex-coffee": "0.2.0",
-        "escomplex": "1.1.0",
-        "check-types": "2.1.x",
-        "commander": "2.0.x"
-    },
-    "devDependencies": {
-        "jshint": "2.1.x",
-        "mocha": "1.13.x",
-        "chai": "1.8.x"
-    },
-    "scripts": {
-        "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",
-        "test": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test"
-    }
+  "name": "complexity-report",
+  "version": "1.3.2",
+  "description": "Software complexity analysis for JavaScript projects",
+  "homepage": "https://github.com/philbooth/complexity-report",
+  "bugs": "https://github.com/philbooth/complexity-report/issues",
+  "license": "MIT",
+  "author": "Phil Booth <pmbooth@gmail.com>",
+  "bin": {
+    "cr": "./src/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/philbooth/complexity-report.git"
+  },
+  "keywords": [
+    "complexity",
+    "simplicity",
+    "cyclomatic",
+    "halstead",
+    "maintainability",
+    "static",
+    "analysis",
+    "metrics",
+    "escomplex"
+  ],
+  "dependencies": {
+    "async": "^0.9.0",
+    "check-types": "2.1.x",
+    "commander": "2.0.x",
+    "escomplex": "1.2.x",
+    "escomplex-coffee": "0.3.x",
+    "escomplex-js": "1.2.x"
+  },
+  "devDependencies": {
+    "jshint": "2.1.x",
+    "mocha": "1.13.x",
+    "chai": "1.8.x"
+  },
+  "scripts": {
+    "lint": "./node_modules/jshint/bin/jshint src --config config/jshint.json",
+    "test": "./node_modules/mocha/bin/mocha --ui tdd --reporter spec --colors test"
+  }
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-/*globals require, process, console, setImmediate */
+/*globals require, process, console */
 
 'use strict';
 
-var options, formatter, state,
+var options, formatter, state, queue,
 
 cli = require('commander'),
 fs = require('fs'),
@@ -12,23 +12,37 @@ path = require('path'),
 js = require('escomplex-js'),
 coffee = require('escomplex-coffee'),
 escomplex = require('escomplex'),
-check = require('check-types');
+check = require('check-types'),
+async = require('async');
+
 
 parseCommandLine();
 
 state = {
-    starting: true,
-    openFileCount: 0,
     sources: {
-      js: [],
-      coffee: []
+        js: [],
+        coffee: []
     },
-    tooComplex: false,
-    failingModules: []
 };
 
 expectFiles(cli.args, cli.help.bind(cli));
-readFiles(cli.args);
+queue = async.queue(function(filePath, cb) {
+    fs.readFile(filePath, 'utf8', function (err, source) {
+        if (err) {
+            error('readFile', err);
+        }
+
+        if (beginsWithShebang(source)) {
+            source = commentFirstLine(source);
+        }
+
+        setSource(filePath, source);
+        cb();
+    });
+}, cli.maxfiles);
+readFiles(cli.args, function() {
+    console.log('fin');
+});
 
 function parseCommandLine () {
     var config;
@@ -60,6 +74,7 @@ function parseCommandLine () {
         option('-t, --trycatch', 'treat catch clauses as source of cyclomatic complexity').
         option('-n, --newmi', 'use the Microsoft-variant maintainability index (scale of 0 to 100)').
         option('-T, --coffeescript', 'include coffee-script files').
+        option('-S, --nocoresize', 'don\'t calculate core size or visibility matrix').
         parse(process.argv);
 
     config = readConfig(cli.config);
@@ -76,7 +91,8 @@ function parseCommandLine () {
         forin: cli.forin || false,
         trycatch: cli.trycatch || false,
         newmi: cli.newmi || false,
-        ignoreErrors: cli.ignoreerrors || false
+        ignoreErrors: cli.ignoreerrors || false,
+        noCoreSize: cli.nocoresize || false
     };
 
     if (check.unemptyString(cli.format) === false) {
@@ -85,9 +101,9 @@ function parseCommandLine () {
 
     if (check.unemptyString(cli.filepattern) === false) {
         if (cli.coffeescript) {
-          cli.filepattern = '\\.(js|coffee)$';
+            cli.filepattern = '\\.(js|coffee)$';
         } else {
-          cli.filepattern = '\\.js$';
+            cli.filepattern = '\\.js$';
         }
     }
     cli.filepattern = new RegExp(cli.filepattern);
@@ -139,62 +155,49 @@ function expectFiles (paths, noFilesFn) {
     }
 }
 
-function readFiles (paths) {
-    paths.forEach(function (p) {
-        var stat = fs.statSync(p);
-
-        if (stat.isDirectory()) {
-            if ((!cli.dirpattern || cli.dirpattern.test(p)) && (!cli.excludepattern || !cli.excludepattern.test(p))) {
-                readDirectory(p);
-            }
-        } else if (cli.filepattern.test(p)) {
-            conditionallyReadFile(p);
+function readFiles (paths, cb) {
+    async.each(paths, processPath, function(err) {
+        if (err) {
+            error('readFiles', err);
         }
+        queue.drain = function() {
+            getReports();
+            cb();
+        };
     });
-
-    state.starting = false;
 }
 
-function readDirectory (directoryPath) {
-    readFiles(
-        fs.readdirSync(directoryPath).filter(function (p) {
+function processPath(p, cb) {
+    fs.stat(p, function(err, stat) {
+        if (err) {
+            return cb(err);
+        }
+        if (stat.isDirectory()) {
+            if ((!cli.dirpattern || cli.dirpattern.test(p)) && (!cli.excludepattern || !cli.excludepattern.test(p))) {
+                return readDirectory(p, cb);
+            }
+        } else if (cli.filepattern.test(p)) {
+            queue.push(p);
+        }
+        cb();
+    });
+}
+
+function readDirectory (directoryPath, cb) {
+    fs.readdir(directoryPath, function(err, files) {
+        if (err) {
+            return cb(err);
+        }
+        files = files.filter(function (p) {
             return path.basename(p).charAt(0) !== '.' || cli.allfiles;
         }).map(function (p) {
             return path.resolve(directoryPath, p);
-        })
-    );
-}
-
-function conditionallyReadFile (filePath) {
-    if (isOpenFileLimitReached()) {
-        setImmediate(function () {
-            conditionallyReadFile(filePath);
         });
-    } else {
-        readFile(filePath);
-    }
-}
-
-function readFile (filePath) {
-    state.openFileCount += 1;
-
-    fs.readFile(filePath, 'utf8', function (err, source) {
-        if (err) {
-            error('readFile', err);
+        if (!files.length) {
+            return cb();
         }
-
-        state.openFileCount -= 1;
-
-        if (beginsWithShebang(source)) {
-            source = commentFirstLine(source);
-        }
-
-        setSource(filePath, source);
+        async.each(files, processPath, cb);
     });
-}
-
-function isOpenFileLimitReached () {
-    return state.openFileCount >= cli.maxfiles;
 }
 
 function error (functionName, err) {
@@ -220,10 +223,6 @@ function setSource (modulePath, source) {
         path: modulePath,
         code: source
     });
-
-    if (state.starting === false && state.openFileCount === 0) {
-        getReports();
-    }
 }
 
 function getType(modulePath) {
@@ -234,10 +233,11 @@ function getReports () {
     var jsResult, coffeeResult, result, failingModules;
 
     try {
-        jsResult = js.analyse(state.sources.js, options);
         if (cli.coffeescript) {
+            options.skipProcess = true;
             coffeeResult = coffee.analyse(state.sources.coffee, options);
         }
+        jsResult = js.analyse(state.sources.js, options);
         result = mergeResults(jsResult, coffeeResult);
 
         if (!cli.silent) {
@@ -259,13 +259,13 @@ function getReports () {
 
 // merge the array of reports together and rerun through the code to compute aggregates
 function mergeResults(jsRes, coffeeRes) {
-  if (!coffeeRes) {
-      return jsRes;
-  }
+    if (!coffeeRes) {
+        return jsRes;
+    }
 
-  jsRes.reports = jsRes.reports.concat(coffeeRes.reports);
+    jsRes.reports = jsRes.reports.concat(coffeeRes.reports);
 
-  return escomplex.processResults(jsRes);
+    return escomplex.processResults(jsRes, cli.nocoresize || false);
 }
 
 function writeReports (result) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,6 @@ queue = async.queue(function(filePath, cb) {
     });
 }, cli.maxfiles);
 readFiles(cli.args, function() {
-    console.log('fin');
 });
 
 function parseCommandLine () {
@@ -234,7 +233,7 @@ function getReports () {
 
     try {
         if (cli.coffeescript) {
-            options.skipProcess = true;
+            options.skipCalculation = true;
             coffeeResult = coffee.analyse(state.sources.coffee, options);
         }
         jsResult = js.analyse(state.sources.js, options);

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ function parseCommandLine () {
         option('-t, --trycatch', 'treat catch clauses as source of cyclomatic complexity').
         option('-n, --newmi', 'use the Microsoft-variant maintainability index (scale of 0 to 100)').
         option('-T, --coffeescript', 'include coffee-script files').
-        option('-S, --nocoresize', 'don\'t calculate core size or visibility matrix').
+        option('-Q, --nocoresize', 'don\'t calculate core size or visibility matrix').
         parse(process.argv);
 
     config = readConfig(cli.config);


### PR DESCRIPTION
I changed the way files are loaded quite a bit.

When running on a large project (around 2500 files) I was getting weird issues with getReports being run twice, which I am fairly sure was due to a race condition with the existing implementation where the number of files could count down to 0 but still have some callbacks pending.

Also, this adds relevant options to make use of `skipCalculation` when merging js/coffee projects and also allow for skipping calculating core size, since it can still be so expensive for large projects.
